### PR TITLE
Add `x-pre-hashed` field during command initialisation

### DIFF
--- a/command.py
+++ b/command.py
@@ -13,7 +13,7 @@ class Command(object):
         try:
             self.data = json.loads(data)
             pre_hashed = 'x-pre-hashed' in self.data
-            if 'pwd' in self.data and not pre_hased:
+            if 'pwd' in self.data and not pre_hashed:
                 self.data['pwd'] = hashlib.sha256(self.data['pwd']).hexdigest()
         except ValueError, KeyError:
             self.error("Unable to decode request JSON")

--- a/command.py
+++ b/command.py
@@ -12,9 +12,10 @@ class Command(object):
         self.sock = sock
         try:
             self.data = json.loads(data)
-            if self.data['pwd']:
+            pre_hashed = 'x-pre-hashed' in self.data
+            if 'pwd' in self.data and not pre_hased:
                 self.data['pwd'] = hashlib.sha256(self.data['pwd']).hexdigest()
-        except ValueError:
+        except ValueError, KeyError:
             self.error("Unable to decode request JSON")
             self._handle = False
             return


### PR DESCRIPTION
This patch allows clients to store the SHA-256 hash of the password in their bloostamp file.
This doesn't really inherently make it a more secure system, but allows clients to **not** store a password, allowing user input when required (only during sending coins). This also means that users can use a password they can easily remember, perhaps saving the day.

The only drawback here is that this is still entirely vulnerable to a MITM attack, so SSL would have to be implemented.

Usage is simply as such:

``` json
{
    "cmd": "send_coin",
    "to": "FOO123456....",
    "addr": "HYPOTHETICAL_BLOOCOIN_ADDRESS",
    "pwd": "sha256123aef5A....", // clearly not real
    "x-pre-hashed": null
}
```

So this coupled with SSL could make bloostamps less like a "come and get me" and more just an easy way for clients to store relevant addresses.
After this, to keep semi-backwards compatibility (e.g. it won't break a client but transactions will fail), a new bloostamp could look like such: `HYPOTHETICAL_BLOOCOIN_ADDRESS::CLIENT_1` (an empty password block, and the client identifier at the end, which would be optional).

Discussions would be nice, I'm not 100% this is a decent addition, but in my mind it could clean up how clients interact with users. Definitely SSL would be required to really make this better.
